### PR TITLE
Avoid memory starvation by aggregating events using external storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Build and install with Gradle:
 Setup an alias:
 
     alias gcc2ss=$(pwd)/build/install/gcc2speedscope/bin/gcc2speedscope
-    
+
 ## Using
 
 Produce a speedscope document from a Gradle debug log file:
 
     $ gcc2ss ~/my/debug.log >> speedscope.json
-    
+
 Produce a speedscope document from a Gradle build:
 
     $ ./gradlew assemble --configuration-cache -d | gcc2ss -- >> speedscope.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,14 +3,17 @@ plugins {
     application
 }
 
-version = "0.1.0"
+version = "0.2.0"
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation("com.beust:klaxon:5.5")
+    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.h2database:h2:2.2.220")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 
     // Align versions of all Kotlin components
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))

--- a/src/main/kotlin/gcc2speedscope/App.kt
+++ b/src/main/kotlin/gcc2speedscope/App.kt
@@ -22,14 +22,15 @@ fun main(args: Array<String>) {
         exitProcess(1)
     }
 
-    val reader = when (val fileName = args[0]) {
+    val debugLogReader = when (val fileName = args[0]) {
         "--" -> System.`in`.bufferedReader()
         else -> newBufferedReader(Paths.get(fileName))
     }
 
     System.out.bufferedWriter().use { writer ->
         writeSpeedscopeDocumentTo(
-            writer, reader,
+            writer,
+            debugLogReader,
             prettyPrint = System.getenv("GCC2SS_PRETTY_PRINT") !== null,
             databaseFile = System.getenv("GCC2SS_DATABASE") ?: createTempDatabaseFile()
         )
@@ -49,7 +50,8 @@ fun writeSpeedscopeDocumentTo(
     databaseFile: String
 ): Unit = runBlocking {
 
-    val channelCapacity = System.getenv("GCC2SS_CHANNEL_CAPACITY")?.toInt() ?: 1024
+    val channelCapacity = System.getenv("GCC2SS_CHANNEL_CAPACITY")?.toInt()
+        ?: 1024
 
     // Launch `parser`
     val events = Channel<ParsedEvent>(channelCapacity)

--- a/src/main/kotlin/gcc2speedscope/App.kt
+++ b/src/main/kotlin/gcc2speedscope/App.kt
@@ -1,12 +1,15 @@
 package gcc2speedscope
 
-import com.beust.klaxon.JsonObject
-import com.beust.klaxon.KlaxonException
-import com.beust.klaxon.Parser
-import com.beust.klaxon.Render.renderValue
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
+import com.google.gson.stream.JsonWriter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.io.Reader
-import java.io.StringReader
 import java.io.Writer
+import java.nio.file.Files
 import java.nio.file.Files.newBufferedReader
 import java.nio.file.Paths
 import java.util.regex.Pattern
@@ -24,26 +27,190 @@ fun main(args: Array<String>) {
         else -> newBufferedReader(Paths.get(fileName))
     }
 
-    val log = parseConfigurationCacheDebugLog(reader)
     System.out.bufferedWriter().use { writer ->
-        writer.writeSpeedscopeDocumentFor(log)
+        writeSpeedscopeDocumentTo(
+            writer, reader,
+            prettyPrint = System.getenv("GCC2SS_PRETTY_PRINT") !== null,
+            databaseFile = System.getenv("GCC2SS_DATABASE") ?: createTempDatabaseFile()
+        )
     }
 }
 
 
-data class Log(
-    val frames: List<String>,
-    val profiles: List<Profile>
-)
+private
+fun createTempDatabaseFile() =
+    Files.createTempFile("gcc2speedscope", "db").toString()
 
 
-data class Profile(
-    val name: String,
-    val events: List<Map<String, Any>>
-)
+fun writeSpeedscopeDocumentTo(
+    writer: Writer,
+    debugLogReader: Reader,
+    prettyPrint: Boolean,
+    databaseFile: String
+): Unit = runBlocking {
+
+    val channelCapacity = System.getenv("GCC2SS_CHANNEL_CAPACITY")?.toInt() ?: 1024
+
+    // Launch `parser`
+    val events = Channel<ParsedEvent>(channelCapacity)
+    launch(Dispatchers.IO) {
+        try {
+            debugLogReader.useLines { lines ->
+                for (e in configurationCacheEventsFromDebugLogLines(lines)) {
+                    events.send(e)
+                }
+            }
+        } finally {
+            events.close()
+        }
+    }
+
+    // Launch `aggregator`
+    val aggregates = Channel<Aggregate>(channelCapacity)
+    launch(Dispatchers.IO) {
+        try {
+            aggregateEvents(events, aggregates, databaseFile)
+        } finally {
+            aggregates.close()
+        }
+    }
+
+    // Launch `writer`
+    launch(Dispatchers.IO) {
+        writeJsonTo(writer, aggregates, prettyPrint)
+    }
+}
 
 
-data class Event(
+private
+suspend fun aggregateEvents(
+    events: Channel<ParsedEvent>,
+    aggregates: Channel<Aggregate>,
+    databaseFile: String
+) {
+    EventStore(databaseFile).use { eventStore ->
+
+        // Insert all events while notifying the writer whenever a new frame is discovered
+        for (e in events) {
+            eventStore.store(e)?.let { newFrame ->
+                aggregates.send(Aggregate.Frame(newFrame))
+            }
+        }
+
+        // Notify writer about all profiles
+        for (p in eventStore.queryProfiles()) {
+            aggregates.send(Aggregate.BeginProfile(p.name, p.lastValue))
+
+            for (e in eventStore.eventsOf(p)) {
+                aggregates.send(
+                    Aggregate.Event(
+                        e.type,
+                        e.frameIndex - 1 /* db is one-based, output model is zero-based */,
+                        e.at
+                    )
+                )
+            }
+        }
+    }
+}
+
+
+private
+suspend fun writeJsonTo(
+    writer: Writer,
+    aggregates: Channel<Aggregate>,
+    prettyPrint: Boolean
+) {
+    JsonWriter(writer).run {
+        if (prettyPrint) {
+            setIndent("  ")
+        }
+        beginObject()
+        name("exporter").value("gcc2speedscope@0.1.0")
+        name("${'$'}schema").value("https://www.speedscope.app/file-format-schema.json")
+        name("activeProfileIndex").value(0)
+
+        var next: Aggregate?
+
+        name("shared")
+        run {
+            beginObject()
+            name("frames")
+            beginArray()
+            while (true) {
+                when (val f = aggregates.receive()) {
+                    is Aggregate.Frame -> {
+                        beginObject()
+                        name("name").value(f.name)
+                        endObject()
+                    }
+
+                    else -> {
+                        next = f
+                        break
+                    }
+                }
+            }
+            endArray()
+            endObject()
+        }
+
+        name("profiles")
+        run {
+            beginArray()
+            while (next !== null) {
+                val profile = next as Aggregate.BeginProfile
+                val startValue = 0 // or should it be `events.first().payload.at` ?
+                val endValue = profile.lastValue
+                beginObject()
+                name("type").value("evented")
+                name("name").value(profile.name)
+                name("unit").value("bytes")
+                name("startValue").value(startValue)
+                name("endValue").value(endValue)
+                name("events")
+                beginArray()
+                while (true) {
+                    when (val e = aggregates.receiveCatching().takeIf { !it.isClosed }?.getOrThrow()) {
+                        is Aggregate.Event -> {
+                            beginObject()
+                            name("type").value(e.type)
+                            name("frame").value(e.frameIndex)
+                            name("at").value(e.at)
+                            endObject()
+                        }
+
+                        else -> {
+                            next = e
+                            break
+                        }
+                    }
+                }
+                endArray()
+                endObject()
+            }
+            endArray()
+        }
+        name("name").value("Gradle Configuration Cache Space Usage")
+        endObject()
+        flush()
+    }
+}
+
+
+/**
+ * Messages sent from [the event aggregator][aggregateEvents] are sent in the following order:
+ *   `Frame+, (BeginProfile, Event+)+`
+ */
+private
+sealed interface Aggregate {
+    data class Frame(val name: String) : Aggregate
+    data class BeginProfile(val name: String, val lastValue: Long) : Aggregate
+    data class Event(val type: String, val frameIndex: Long, val at: Long) : Aggregate
+}
+
+
+data class ParsedEvent(
     val sequenceNumber: Long,
     val profile: String,
     val type: String,
@@ -52,111 +219,27 @@ data class Event(
 )
 
 
-internal
-fun Writer.writeSpeedscopeDocumentFor(log: Log, prettyPrint: Boolean = false) {
-    renderValue(
-        speedscopeDocumentFor(log),
-        result = this,
-        canonical = false,
-        prettyPrint = prettyPrint,
-        level = 0
-    )
-}
-
-
 private
-fun speedscopeDocumentFor(log: Log) = mapOf<String, Any>(
-    "exporter" to "gcc2speedscope@0.1.0",
-    "${'$'}schema" to "https://www.speedscope.app/file-format-schema.json",
-    "activeProfileIndex" to log.profiles
-        .indexOfFirst { profile -> profile.name == "state" }
-        .let { index -> if (index == -1) 0 else index },
-    "shared" to mapOf(
-        "frames" to log.frames.map {
-            mapOf("name" to it)
-        }
-    ),
-    "profiles" to log.profiles.map { profile ->
-        val events = profile.events
-        val startValue = 0 // or should it be `events.first().payload.at` ?
-        val endValue = events.last()["at"]
-        mapOf(
-            "type" to "evented",
-            "name" to profile.name,
-            "unit" to "bytes",
-            "startValue" to startValue,
-            "endValue" to endValue,
-            "events" to events
-        )
-    },
-    "name" to "Gradle Configuration Cache Space Usage"
-)
-
-
-internal
-fun parseConfigurationCacheDebugLog(reader: Reader): Log =
-    reader.useLines {
-        speedscopeLogFor(
-            configurationCacheEventsFromDebugLogLines(it)
-        )
-    }
-
-
-private
-fun speedscopeLogFor(events: Sequence<Event>): Log {
-    val frames = LinkedHashMap<String, Int>()
-    val profiles = HashMap<String, ArrayList<Pair<Int, Event>>>()
-    events.forEach { event ->
-        // map frame name to frame index
-        val frameIndex = frames.computeIfAbsent(event.frame) { frames.size }
-
-        // group events by category
-        profiles
-            .computeIfAbsent(event.profile) { ArrayList() }
-            .add(frameIndex to event)
-    }
-    return Log(
-        frames.keys.toList(),
-        profiles.map { (name, events) ->
-            Profile(
-                name,
-                events.apply {
-                    sortBy { (_, event) -> event.sequenceNumber }
-                }.map { (frameIndex, event) ->
-                    mapOf(
-                        "type" to event.type,
-                        "frame" to frameIndex,
-                        "at" to event.at
-                    )
-                }
-            )
-        }
-    )
-}
-
-
-private
-fun configurationCacheEventsFromDebugLogLines(lines: Sequence<String>) = sequence<Event> {
+fun configurationCacheEventsFromDebugLogLines(lines: Sequence<String>) = sequence {
     // Example log line:
     // 2020-08-13T15:19:11.495-0300 [DEBUG] [org.gradle.configurationcache.DefaultConfigurationCache] {"profile":"state","type":"O","frame":"Gradle","at":6,"sn":1}
     val linePattern = logLinePattern()
-    val jsonParser = Parser.default()
     lines.forEachIndexed { index, line ->
         val matcher = linePattern.matcher(line)
         if (matcher.matches()) {
             val jsonEvent = matcher.group(1)
             try {
-                val jsonObject = jsonParser.parse(StringReader(jsonEvent)) as JsonObject
+                val jsonObject = JsonParser.parseString(jsonEvent).asJsonObject
                 yield(jsonObject.run {
-                    Event(
-                        sequenceNumber = long("sn")!!,
-                        profile = string("profile")!!,
-                        type = string("type")!!,
-                        frame = string("frame")!!,
-                        at = long("at")!!
+                    ParsedEvent(
+                        sequenceNumber = get("sn")!!.asLong,
+                        profile = get("profile")!!.asString,
+                        type = get("type")!!.asString,
+                        frame = get("frame")!!.asString,
+                        at = get("at")!!.asLong
                     )
                 })
-            } catch (e: KlaxonException) {
+            } catch (e: JsonParseException) {
                 throw IllegalArgumentException("line ${index + 1}: failed to parse $jsonEvent", e)
             }
         }

--- a/src/main/kotlin/gcc2speedscope/App.kt
+++ b/src/main/kotlin/gcc2speedscope/App.kt
@@ -126,7 +126,7 @@ suspend fun writeJsonTo(
             setIndent("  ")
         }
         beginObject()
-        name("exporter").value("gcc2speedscope@0.1.0")
+        name("exporter").value("gcc2speedscope@0.2.0")
         name("${'$'}schema").value("https://www.speedscope.app/file-format-schema.json")
         name("activeProfileIndex").value(0)
 

--- a/src/main/kotlin/gcc2speedscope/EventStore.kt
+++ b/src/main/kotlin/gcc2speedscope/EventStore.kt
@@ -1,0 +1,200 @@
+package gcc2speedscope
+
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.Statement
+
+
+class EventStore(database: String) : AutoCloseable {
+
+    private
+    val conn = DriverManager.getConnection("jdbc:h2:$database", "sa", "")
+
+    init {
+        createStatement().execute(
+            """
+            CREATE TABLE frames (
+                frame_id INT AUTO_INCREMENT PRIMARY KEY,
+                frame TEXT NOT NULL,
+                UNIQUE (frame)
+            );
+
+            CREATE TABLE profiles (
+                profile_id INT AUTO_INCREMENT PRIMARY KEY,
+                profile TEXT NOT NULL,
+                UNIQUE (profile)
+            );
+
+            CREATE TABLE events (
+                event_id INT AUTO_INCREMENT PRIMARY KEY,
+                sn BIGINT,
+                profile_id INT NOT NULL,
+                type CHAR(1),
+                frame_id INT NOT NULL,
+                at BIGINT,
+                UNIQUE (profile_id, sn)
+-- The next constraint prevents the better UNIQUE index to be used for queries so it's not included
+--                ,FOREIGN KEY (profile_id) REFERENCES profiles(profile_id)
+-- The next constraint is excluded for performance
+--                ,FOREIGN KEY (frame_id) REFERENCES frames(frame_id)
+            );
+
+            CREATE INDEX idx_frame ON frames(frame);
+
+            CREATE INDEX idx_profile ON profiles(profile);
+
+            """.trimIndent()
+        )
+    }
+
+    private
+    val selectFrame = prepare("SELECT frame_id FROM frames WHERE frame = ?")
+
+    private
+    val insertFrame = prepareInsert("INSERT INTO frames (frame) VALUES (?)")
+
+    private
+    val selectProfile = prepare("SELECT profile_id FROM profiles WHERE profile = ?")
+
+    private
+    val insertProfile = prepareInsert("INSERT INTO profiles (profile) VALUES (?)")
+
+    private
+    val insertEvent = prepare("INSERT INTO events (sn, profile_id, type, frame_id, at) VALUES (?, ?, ?, ?, ?)")
+
+    data class Profile(
+        val id: Long,
+        val name: String,
+        val lastValue: Long
+    )
+
+    data class Event(
+        val type: String,
+        val frameIndex: Long,
+        val at: Long
+    )
+
+    fun queryProfiles(): Sequence<Profile> = sequence {
+
+        val queryLastValue = prepare("SELECT at FROM events WHERE profile_id = ? ORDER BY sn DESC LIMIT 1")
+
+        forEachIn("SELECT profile_id, profile FROM profiles") {
+            val id = getLong(1)
+            val lastValue = queryLastValue.run {
+                setLong(1, id)
+                executeQuery().run {
+                    require(next())
+                    getLong(1)
+                }
+            }
+            yield(Profile(id, getString(2), lastValue))
+        }
+    }
+
+    fun eventsOf(p: Profile): Sequence<Event> = sequence {
+        forEachIn("SELECT type, frame_id, at FROM events WHERE profile_id = ${p.id} ORDER BY sn ASC") {
+            yield(
+                Event(
+                    type = getString(1),
+                    frameIndex = getLong(2),
+                    at = getLong(3)
+                )
+            )
+        }
+    }
+
+    /**
+     * Stores the given event and returns its frame name if it's the first time it appears.
+     */
+    fun store(e: ParsedEvent): String? {
+        try {
+            val existingFrameIndex = frameIndexOf(e.frame)
+            if (existingFrameIndex != null) {
+                store(e, existingFrameIndex)
+                return null
+            }
+            val newFrameIndex = insertFrame(e.frame)
+            store(e, newFrameIndex)
+            return e.frame
+        } catch (x: Exception) {
+            throw IllegalStateException("Failed to store event `$e`.", x)
+        }
+    }
+
+    override fun close() {
+        conn.close()
+    }
+
+    private
+    fun store(e: ParsedEvent, frameIndex: Long) {
+        val profileId = insertProfileIfAbsent(e.profile)
+        insertEvent.run {
+            setLong(1, e.sequenceNumber)
+            setLong(2, profileId)
+            setString(3, e.type)
+            setLong(4, frameIndex)
+            setLong(5, e.at)
+            execute()
+        }
+    }
+
+    private
+    fun insertProfileIfAbsent(profile: String) =
+        selectProfile.queryLong(profile)
+            ?: insertProfile.insertAndGetGeneratedKey(profile)
+
+    private
+    fun frameIndexOf(frameName: String): Long? =
+        selectFrame.queryLong(frameName)
+
+    private
+    fun insertFrame(frameName: String): Long =
+        insertFrame.insertAndGetGeneratedKey(frameName)
+
+    private
+    fun PreparedStatement.insertAndGetGeneratedKey(stringParam: String): Long = run {
+        setString(1, stringParam)
+        executeUpdate()
+        generatedKeys.use { rs ->
+            rs.firstLong()!!
+        }
+    }
+
+    private
+    fun PreparedStatement.queryLong(stringParam: String): Long? = run {
+        setString(1, stringParam)
+        executeQuery().use { rs ->
+            rs.firstLong()
+        }
+    }
+
+    private
+    fun ResultSet.firstLong() =
+        takeIf { it.next() }?.getLong(1)
+
+    private
+    inline fun forEachIn(query: String, action: ResultSet.() -> Unit) {
+        resultSet(query).use { rs ->
+            while (rs.next()) {
+                action(rs)
+            }
+        }
+    }
+
+    private
+    fun resultSet(query: String): ResultSet =
+        createStatement().executeQuery(query)
+
+    private
+    fun createStatement(): Statement =
+        conn.createStatement()
+
+    private
+    fun prepareInsert(sql: String): PreparedStatement =
+        conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
+
+    private
+    fun prepare(sql: String): PreparedStatement =
+        conn.prepareStatement(sql)
+}

--- a/src/test/kotlin/gcc2speedscope/AppTest.kt
+++ b/src/test/kotlin/gcc2speedscope/AppTest.kt
@@ -1,30 +1,38 @@
 package gcc2speedscope
 
-import java.io.BufferedReader
-import java.io.StringWriter
+import org.junit.jupiter.api.io.TempDir
+import java.io.Reader
+import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class AppTest {
 
     @Test
-    fun `produces expected json`() {
-        val speedscopeDocument = speedscopeDocumentFor(bufferedReaderForResource("/debug.log"))
+    fun `produces expected json`(@TempDir tempDir: Path) {
+        val outputFile = tempDir.resolve("actual.json")
+        writeSpeedscopeDocumentFor(
+            bufferedReaderForResource("/debug.log"),
+            outputFile,
+            prettyPrint = true
+        )
+
         // uncomment to update expected file
         // java.io.File("./src/test/resources/expected.json").writeText(speedscopeDocument)
         assertEquals(
             bufferedReaderForResource("/expected.json").readText(),
-            speedscopeDocument
+            outputFile.toFile().readText()
         )
     }
 
     private
-    fun speedscopeDocumentFor(debugLog: BufferedReader): String = StringWriter().run {
-        writeSpeedscopeDocumentFor(parseConfigurationCacheDebugLog(debugLog), prettyPrint = true)
-        toString()
+    fun writeSpeedscopeDocumentFor(debugLogReader: Reader, outputFile: Path, prettyPrint: Boolean = false) {
+        outputFile.toFile().bufferedWriter().use { writer ->
+            writeSpeedscopeDocumentTo(writer, debugLogReader, prettyPrint, "$outputFile.db")
+        }
     }
 
     private
     fun bufferedReaderForResource(resource: String) =
-        javaClass.getResourceAsStream(resource).bufferedReader()
+        javaClass.getResourceAsStream(resource)!!.bufferedReader()
 }

--- a/src/test/resources/expected.json
+++ b/src/test/resources/expected.json
@@ -1,5 +1,5 @@
 {
-  "exporter": "gcc2speedscope@0.1.0",
+  "exporter": "gcc2speedscope@0.2.0",
   "$schema": "https://www.speedscope.app/file-format-schema.json",
   "activeProfileIndex": 0,
   "shared": {

--- a/src/test/resources/expected.json
+++ b/src/test/resources/expected.json
@@ -1,1390 +1,1775 @@
 {
   "exporter": "gcc2speedscope@0.1.0",
   "$schema": "https://www.speedscope.app/file-format-schema.json",
-  "activeProfileIndex": 1,
+  "activeProfileIndex": 0,
   "shared": {
-    "frames": [{
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InitScripts"
-    }, {
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InitScripts.fingerprints"
-    }, {
-      "name": "java.util.ArrayList"
-    }, {
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$GradleEnvironment"
-    }, {
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$GradleEnvironment.gradleUserHomeDir"
-    }, {
-      "name": "java.io.File"
-    }, {
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$GradleEnvironment.jvm"
-    }, {
-      "name": "java.lang.String"
-    }, {
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InputFile"
-    }, {
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InputFile.file"
-    }, {
-      "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InputFile.hash"
-    }, {
-      "name": "org.gradle.internal.hash.HashCode"
-    }, {
-      "name": "Gradle"
-    }, {
-      "name": "included builds"
-    }, {
-      "name": "build cache"
-    }, {
-      "name": "org.gradle.caching.local.DirectoryBuildCache"
-    }, {
-      "name": "org.gradle.caching.local.DirectoryBuildCache_Decorated._gr_dn_"
-    }, {
-      "name": "org.gradle.caching.local.DirectoryBuildCache_Decorated._gr_owner_"
-    }, {
-      "name": "org.gradle.caching.local.DirectoryBuildCache.directory"
-    }, {
-      "name": "org.gradle.caching.local.DirectoryBuildCache.removeUnusedEntriesAfterDays"
-    }, {
-      "name": "java.lang.Integer"
-    }, {
-      "name": "org.gradle.caching.configuration.AbstractBuildCache.enabled"
-    }, {
-      "name": "java.lang.Boolean"
-    }, {
-      "name": "org.gradle.caching.configuration.AbstractBuildCache.push"
-    }, {
-      "name": "listener subscriptions"
-    }, {
-      "name": "cleanup registrations"
-    }, {
-      "name": "Work Graph"
-    }, {
-      "name": "org.gradle.execution.plan.LocalTaskNode"
-    }, {
-      "name": ":ok"
-    }, {
-      "name": "org.gradle.api.DefaultTask"
-    }, {
-      "name": "org.gradle.api.DefaultTask_Decorated._gr_dn_"
-    }, {
-      "name": "org.gradle.internal.Describables$2"
-    }, {
-      "name": "org.gradle.internal.Describables$2.val$name"
-    }, {
-      "name": "org.gradle.internal.Describables$2.val$type"
-    }, {
-      "name": "org.gradle.api.DefaultTask_Decorated._gr_owner_"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask.actions"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction.actionName"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction.application"
-    }, {
-      "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication"
-    }, {
-      "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication.displayName"
-    }, {
-      "name": "org.gradle.internal.Describables$1"
-    }, {
-      "name": "org.gradle.internal.Describables$1.val$description"
-    }, {
-      "name": "org.gradle.internal.Describables$1.val$value"
-    }, {
-      "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication.id"
-    }, {
-      "name": "org.gradle.configuration.internal.UserCodeApplicationId"
-    }, {
-      "name": "org.gradle.configuration.internal.UserCodeApplicationId.id"
-    }, {
-      "name": "java.lang.Long"
-    }, {
-      "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication.this$0"
-    }, {
-      "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext"
-    }, {
-      "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext.currentApplication"
-    }, {
-      "name": "java.lang.ThreadLocal"
-    }, {
-      "name": "java.lang.ThreadLocal.threadLocalHashCode"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction.closure"
-    }, {
-      "name": "build_exkq6qzuau806my23tc1b64nl$_run_closure1$_closure2$_closure3"
-    }, {
-      "name": "groovy.lang.Closure.bcw"
-    }, {
-      "name": "groovy.lang.Closure.delegate"
-    }, {
-      "name": "groovy.lang.Closure.directive"
-    }, {
-      "name": "groovy.lang.Closure.maximumNumberOfParameters"
-    }, {
-      "name": "groovy.lang.Closure.owner"
-    }, {
-      "name": "groovy.lang.Closure.parameterTypes"
-    }, {
-      "name": "java.lang.Class[]"
-    }, {
-      "name": "java.lang.Class"
-    }, {
-      "name": "groovy.lang.Closure.resolveStrategy"
-    }, {
-      "name": "groovy.lang.Closure.thisObject"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask.enabled"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask.onlyIfSpec"
-    }, {
-      "name": "org.gradle.api.specs.AndSpec"
-    }, {
-      "name": "org.gradle.api.specs.CompositeSpec.specs"
-    }, {
-      "name": "org.gradle.api.specs.Spec[]"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask$8"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask$8.this$0"
-    }, {
-      "name": "org.gradle.api.internal.AbstractTask.timeout"
-    }, {
-      "name": "org.gradle.api.internal.provider.DefaultProperty"
-    }, {
-      "name": ":sub:ok"
-    }]
+    "frames": [
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InitScripts"
+      },
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InitScripts.fingerprints"
+      },
+      {
+        "name": "java.util.ArrayList"
+      },
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$GradleEnvironment"
+      },
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$GradleEnvironment.gradleUserHomeDir"
+      },
+      {
+        "name": "java.io.File"
+      },
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$GradleEnvironment.jvm"
+      },
+      {
+        "name": "java.lang.String"
+      },
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InputFile"
+      },
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InputFile.file"
+      },
+      {
+        "name": "org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint$InputFile.hash"
+      },
+      {
+        "name": "org.gradle.internal.hash.HashCode"
+      },
+      {
+        "name": "Gradle"
+      },
+      {
+        "name": "included builds"
+      },
+      {
+        "name": "build cache"
+      },
+      {
+        "name": "org.gradle.caching.local.DirectoryBuildCache"
+      },
+      {
+        "name": "org.gradle.caching.local.DirectoryBuildCache_Decorated._gr_dn_"
+      },
+      {
+        "name": "org.gradle.caching.local.DirectoryBuildCache_Decorated._gr_owner_"
+      },
+      {
+        "name": "org.gradle.caching.local.DirectoryBuildCache.directory"
+      },
+      {
+        "name": "org.gradle.caching.local.DirectoryBuildCache.removeUnusedEntriesAfterDays"
+      },
+      {
+        "name": "java.lang.Integer"
+      },
+      {
+        "name": "org.gradle.caching.configuration.AbstractBuildCache.enabled"
+      },
+      {
+        "name": "java.lang.Boolean"
+      },
+      {
+        "name": "org.gradle.caching.configuration.AbstractBuildCache.push"
+      },
+      {
+        "name": "listener subscriptions"
+      },
+      {
+        "name": "cleanup registrations"
+      },
+      {
+        "name": "Work Graph"
+      },
+      {
+        "name": "org.gradle.execution.plan.LocalTaskNode"
+      },
+      {
+        "name": ":ok"
+      },
+      {
+        "name": "org.gradle.api.DefaultTask"
+      },
+      {
+        "name": "org.gradle.api.DefaultTask_Decorated._gr_dn_"
+      },
+      {
+        "name": "org.gradle.internal.Describables$2"
+      },
+      {
+        "name": "org.gradle.internal.Describables$2.val$name"
+      },
+      {
+        "name": "org.gradle.internal.Describables$2.val$type"
+      },
+      {
+        "name": "org.gradle.api.DefaultTask_Decorated._gr_owner_"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask.actions"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction.actionName"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction.application"
+      },
+      {
+        "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication"
+      },
+      {
+        "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication.displayName"
+      },
+      {
+        "name": "org.gradle.internal.Describables$1"
+      },
+      {
+        "name": "org.gradle.internal.Describables$1.val$description"
+      },
+      {
+        "name": "org.gradle.internal.Describables$1.val$value"
+      },
+      {
+        "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication.id"
+      },
+      {
+        "name": "org.gradle.configuration.internal.UserCodeApplicationId"
+      },
+      {
+        "name": "org.gradle.configuration.internal.UserCodeApplicationId.id"
+      },
+      {
+        "name": "java.lang.Long"
+      },
+      {
+        "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext$CurrentApplication.this$0"
+      },
+      {
+        "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext"
+      },
+      {
+        "name": "org.gradle.configuration.internal.DefaultUserCodeApplicationContext.currentApplication"
+      },
+      {
+        "name": "java.lang.ThreadLocal"
+      },
+      {
+        "name": "java.lang.ThreadLocal.threadLocalHashCode"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask$ClosureTaskAction.closure"
+      },
+      {
+        "name": "build_exkq6qzuau806my23tc1b64nl$_run_closure1$_closure2$_closure3"
+      },
+      {
+        "name": "groovy.lang.Closure.bcw"
+      },
+      {
+        "name": "groovy.lang.Closure.delegate"
+      },
+      {
+        "name": "groovy.lang.Closure.directive"
+      },
+      {
+        "name": "groovy.lang.Closure.maximumNumberOfParameters"
+      },
+      {
+        "name": "groovy.lang.Closure.owner"
+      },
+      {
+        "name": "groovy.lang.Closure.parameterTypes"
+      },
+      {
+        "name": "java.lang.Class[]"
+      },
+      {
+        "name": "java.lang.Class"
+      },
+      {
+        "name": "groovy.lang.Closure.resolveStrategy"
+      },
+      {
+        "name": "groovy.lang.Closure.thisObject"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask.enabled"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask.onlyIfSpec"
+      },
+      {
+        "name": "org.gradle.api.specs.AndSpec"
+      },
+      {
+        "name": "org.gradle.api.specs.CompositeSpec.specs"
+      },
+      {
+        "name": "org.gradle.api.specs.Spec[]"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask$8"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask$8.this$0"
+      },
+      {
+        "name": "org.gradle.api.internal.AbstractTask.timeout"
+      },
+      {
+        "name": "org.gradle.api.internal.provider.DefaultProperty"
+      },
+      {
+        "name": ":sub:ok"
+      }
+    ]
   },
-  "profiles": [{
-    "type": "evented",
-    "name": "fingerprint",
-    "unit": "bytes",
-    "startValue": 0,
-    "endValue": 754,
-    "events": [{
-      "type": "O",
-      "frame": 0,
-      "at": 2
-    }, {
-      "type": "O",
-      "frame": 1,
-      "at": 92
-    }, {
-      "type": "O",
-      "frame": 2,
-      "at": 93
-    }, {
-      "type": "C",
-      "frame": 2,
-      "at": 94
-    }, {
-      "type": "C",
-      "frame": 1,
-      "at": 94
-    }, {
-      "type": "C",
-      "frame": 0,
-      "at": 94
-    }, {
-      "type": "O",
-      "frame": 3,
-      "at": 96
-    }, {
-      "type": "O",
-      "frame": 4,
-      "at": 192
-    }, {
-      "type": "O",
-      "frame": 5,
-      "at": 193
-    }, {
-      "type": "C",
-      "frame": 5,
-      "at": 271
-    }, {
-      "type": "C",
-      "frame": 4,
-      "at": 271
-    }, {
-      "type": "O",
-      "frame": 6,
-      "at": 271
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 272
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 320
-    }, {
-      "type": "C",
-      "frame": 6,
-      "at": 320
-    }, {
-      "type": "C",
-      "frame": 3,
-      "at": 320
-    }, {
-      "type": "O",
-      "frame": 8,
-      "at": 322
-    }, {
-      "type": "O",
-      "frame": 9,
-      "at": 410
-    }, {
-      "type": "O",
-      "frame": 5,
-      "at": 411
-    }, {
-      "type": "C",
-      "frame": 5,
-      "at": 563
-    }, {
-      "type": "C",
-      "frame": 9,
-      "at": 563
-    }, {
-      "type": "O",
-      "frame": 10,
-      "at": 563
-    }, {
-      "type": "O",
-      "frame": 11,
-      "at": 564
-    }, {
-      "type": "C",
-      "frame": 11,
-      "at": 581
-    }, {
-      "type": "C",
-      "frame": 10,
-      "at": 581
-    }, {
-      "type": "C",
-      "frame": 8,
-      "at": 581
-    }, {
-      "type": "O",
-      "frame": 8,
-      "at": 583
-    }, {
-      "type": "O",
-      "frame": 9,
-      "at": 586
-    }, {
-      "type": "O",
-      "frame": 5,
-      "at": 587
-    }, {
-      "type": "C",
-      "frame": 5,
-      "at": 736
-    }, {
-      "type": "C",
-      "frame": 9,
-      "at": 736
-    }, {
-      "type": "O",
-      "frame": 10,
-      "at": 736
-    }, {
-      "type": "O",
-      "frame": 11,
-      "at": 737
-    }, {
-      "type": "C",
-      "frame": 11,
-      "at": 754
-    }, {
-      "type": "C",
-      "frame": 10,
-      "at": 754
-    }, {
-      "type": "C",
-      "frame": 8,
-      "at": 754
-    }]
-  }, {
-    "type": "evented",
-    "name": "state",
-    "unit": "bytes",
-    "startValue": 0,
-    "endValue": 2227,
-    "events": [{
-      "type": "O",
-      "frame": 12,
-      "at": 0
-    }, {
-      "type": "O",
-      "frame": 13,
-      "at": 6
-    }, {
-      "type": "C",
-      "frame": 13,
-      "at": 8
-    }, {
-      "type": "O",
-      "frame": 14,
-      "at": 8
-    }, {
-      "type": "O",
-      "frame": 15,
-      "at": 10
-    }, {
-      "type": "O",
-      "frame": 16,
-      "at": 59
-    }, {
-      "type": "C",
-      "frame": 16,
-      "at": 64
-    }, {
-      "type": "O",
-      "frame": 17,
-      "at": 64
-    }, {
-      "type": "C",
-      "frame": 17,
-      "at": 69
-    }, {
-      "type": "O",
-      "frame": 18,
-      "at": 69
-    }, {
-      "type": "C",
-      "frame": 18,
-      "at": 74
-    }, {
-      "type": "O",
-      "frame": 19,
-      "at": 74
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 75
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 79
-    }, {
-      "type": "C",
-      "frame": 19,
-      "at": 79
-    }, {
-      "type": "O",
-      "frame": 21,
-      "at": 79
-    }, {
-      "type": "O",
-      "frame": 22,
-      "at": 80
-    }, {
-      "type": "C",
-      "frame": 22,
-      "at": 81
-    }, {
-      "type": "C",
-      "frame": 21,
-      "at": 81
-    }, {
-      "type": "O",
-      "frame": 23,
-      "at": 81
-    }, {
-      "type": "O",
-      "frame": 22,
-      "at": 82
-    }, {
-      "type": "C",
-      "frame": 22,
-      "at": 83
-    }, {
-      "type": "C",
-      "frame": 23,
-      "at": 83
-    }, {
-      "type": "C",
-      "frame": 15,
-      "at": 83
-    }, {
-      "type": "C",
-      "frame": 14,
-      "at": 88
-    }, {
-      "type": "O",
-      "frame": 24,
-      "at": 88
-    }, {
-      "type": "C",
-      "frame": 24,
-      "at": 89
-    }, {
-      "type": "O",
-      "frame": 25,
-      "at": 89
-    }, {
-      "type": "C",
-      "frame": 25,
-      "at": 90
-    }, {
-      "type": "C",
-      "frame": 12,
-      "at": 95
-    }, {
-      "type": "O",
-      "frame": 26,
-      "at": 95
-    }, {
-      "type": "O",
-      "frame": 27,
-      "at": 669
-    }, {
-      "type": "O",
-      "frame": 28,
-      "at": 669
-    }, {
-      "type": "O",
-      "frame": 29,
-      "at": 703
-    }, {
-      "type": "O",
-      "frame": 30,
-      "at": 706
-    }, {
-      "type": "O",
-      "frame": 31,
-      "at": 708
-    }, {
-      "type": "O",
-      "frame": 32,
-      "at": 747
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 748
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 752
-    }, {
-      "type": "C",
-      "frame": 32,
-      "at": 752
-    }, {
-      "type": "O",
-      "frame": 33,
-      "at": 752
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 753
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 758
-    }, {
-      "type": "C",
-      "frame": 33,
-      "at": 758
-    }, {
-      "type": "C",
-      "frame": 31,
-      "at": 758
-    }, {
-      "type": "C",
-      "frame": 30,
-      "at": 758
-    }, {
-      "type": "O",
-      "frame": 34,
-      "at": 758
-    }, {
-      "type": "C",
-      "frame": 34,
-      "at": 763
-    }, {
-      "type": "O",
-      "frame": 35,
-      "at": 763
-    }, {
-      "type": "O",
-      "frame": 2,
-      "at": 764
-    }, {
-      "type": "O",
-      "frame": 36,
-      "at": 767
-    }, {
-      "type": "O",
-      "frame": 37,
-      "at": 826
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 827
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 844
-    }, {
-      "type": "C",
-      "frame": 37,
-      "at": 844
-    }, {
-      "type": "O",
-      "frame": 38,
-      "at": 844
-    }, {
-      "type": "O",
-      "frame": 39,
-      "at": 846
-    }, {
-      "type": "O",
-      "frame": 40,
-      "at": 938
-    }, {
-      "type": "O",
-      "frame": 41,
-      "at": 940
-    }, {
-      "type": "O",
-      "frame": 42,
-      "at": 979
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 980
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 991
-    }, {
-      "type": "C",
-      "frame": 42,
-      "at": 991
-    }, {
-      "type": "O",
-      "frame": 43,
-      "at": 991
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 992
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 1005
-    }, {
-      "type": "C",
-      "frame": 43,
-      "at": 1005
-    }, {
-      "type": "C",
-      "frame": 41,
-      "at": 1005
-    }, {
-      "type": "C",
-      "frame": 40,
-      "at": 1005
-    }, {
-      "type": "O",
-      "frame": 44,
-      "at": 1005
-    }, {
-      "type": "O",
-      "frame": 45,
-      "at": 1007
-    }, {
-      "type": "O",
-      "frame": 46,
-      "at": 1067
-    }, {
-      "type": "O",
-      "frame": 47,
-      "at": 1068
-    }, {
-      "type": "C",
-      "frame": 47,
-      "at": 1076
-    }, {
-      "type": "C",
-      "frame": 46,
-      "at": 1076
-    }, {
-      "type": "C",
-      "frame": 45,
-      "at": 1076
-    }, {
-      "type": "C",
-      "frame": 44,
-      "at": 1076
-    }, {
-      "type": "O",
-      "frame": 48,
-      "at": 1076
-    }, {
-      "type": "O",
-      "frame": 49,
-      "at": 1078
-    }, {
-      "type": "O",
-      "frame": 50,
-      "at": 1151
-    }, {
-      "type": "O",
-      "frame": 51,
-      "at": 1153
-    }, {
-      "type": "O",
-      "frame": 52,
-      "at": 1179
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 1180
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 1184
-    }, {
-      "type": "C",
-      "frame": 52,
-      "at": 1184
-    }, {
-      "type": "C",
-      "frame": 51,
-      "at": 1184
-    }, {
-      "type": "C",
-      "frame": 50,
-      "at": 1184
-    }, {
-      "type": "C",
-      "frame": 49,
-      "at": 1184
-    }, {
-      "type": "C",
-      "frame": 48,
-      "at": 1184
-    }, {
-      "type": "C",
-      "frame": 39,
-      "at": 1184
-    }, {
-      "type": "C",
-      "frame": 38,
-      "at": 1184
-    }, {
-      "type": "O",
-      "frame": 53,
-      "at": 1184
-    }, {
-      "type": "O",
-      "frame": 54,
-      "at": 1185
-    }, {
-      "type": "O",
-      "frame": 55,
-      "at": 1771
-    }, {
-      "type": "C",
-      "frame": 55,
-      "at": 1776
-    }, {
-      "type": "O",
-      "frame": 56,
-      "at": 1776
-    }, {
-      "type": "C",
-      "frame": 56,
-      "at": 1781
-    }, {
-      "type": "O",
-      "frame": 57,
-      "at": 1781
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 1782
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 1786
-    }, {
-      "type": "C",
-      "frame": 57,
-      "at": 1786
-    }, {
-      "type": "O",
-      "frame": 58,
-      "at": 1786
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 1787
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 1791
-    }, {
-      "type": "C",
-      "frame": 58,
-      "at": 1791
-    }, {
-      "type": "O",
-      "frame": 59,
-      "at": 1791
-    }, {
-      "type": "C",
-      "frame": 59,
-      "at": 1796
-    }, {
-      "type": "O",
-      "frame": 60,
-      "at": 1796
-    }, {
-      "type": "O",
-      "frame": 61,
-      "at": 1797
-    }, {
-      "type": "O",
-      "frame": 62,
-      "at": 1817
-    }, {
-      "type": "C",
-      "frame": 62,
-      "at": 1836
-    }, {
-      "type": "C",
-      "frame": 61,
-      "at": 1836
-    }, {
-      "type": "C",
-      "frame": 60,
-      "at": 1836
-    }, {
-      "type": "O",
-      "frame": 63,
-      "at": 1836
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 1837
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 1841
-    }, {
-      "type": "C",
-      "frame": 63,
-      "at": 1841
-    }, {
-      "type": "O",
-      "frame": 64,
-      "at": 1841
-    }, {
-      "type": "C",
-      "frame": 64,
-      "at": 1846
-    }, {
-      "type": "C",
-      "frame": 54,
-      "at": 1846
-    }, {
-      "type": "C",
-      "frame": 53,
-      "at": 1846
-    }, {
-      "type": "C",
-      "frame": 36,
-      "at": 1846
-    }, {
-      "type": "C",
-      "frame": 2,
-      "at": 1846
-    }, {
-      "type": "C",
-      "frame": 35,
-      "at": 1846
-    }, {
-      "type": "O",
-      "frame": 65,
-      "at": 1846
-    }, {
-      "type": "O",
-      "frame": 22,
-      "at": 1847
-    }, {
-      "type": "C",
-      "frame": 22,
-      "at": 1848
-    }, {
-      "type": "C",
-      "frame": 65,
-      "at": 1848
-    }, {
-      "type": "O",
-      "frame": 66,
-      "at": 1848
-    }, {
-      "type": "O",
-      "frame": 67,
-      "at": 1850
-    }, {
-      "type": "O",
-      "frame": 68,
-      "at": 1883
-    }, {
-      "type": "O",
-      "frame": 69,
-      "at": 1884
-    }, {
-      "type": "O",
-      "frame": 70,
-      "at": 1915
-    }, {
-      "type": "O",
-      "frame": 71,
-      "at": 1958
-    }, {
-      "type": "O",
-      "frame": 29,
-      "at": 1959
-    }, {
-      "type": "C",
-      "frame": 29,
-      "at": 1960
-    }, {
-      "type": "C",
-      "frame": 71,
-      "at": 1960
-    }, {
-      "type": "C",
-      "frame": 70,
-      "at": 1960
-    }, {
-      "type": "C",
-      "frame": 69,
-      "at": 1960
-    }, {
-      "type": "C",
-      "frame": 68,
-      "at": 1960
-    }, {
-      "type": "C",
-      "frame": 67,
-      "at": 1960
-    }, {
-      "type": "C",
-      "frame": 66,
-      "at": 1960
-    }, {
-      "type": "O",
-      "frame": 72,
-      "at": 1960
-    }, {
-      "type": "O",
-      "frame": 73,
-      "at": 1961
-    }, {
-      "type": "C",
-      "frame": 73,
-      "at": 1983
-    }, {
-      "type": "C",
-      "frame": 72,
-      "at": 1983
-    }, {
-      "type": "C",
-      "frame": 29,
-      "at": 1988
-    }, {
-      "type": "C",
-      "frame": 28,
-      "at": 1988
-    }, {
-      "type": "C",
-      "frame": 27,
-      "at": 1988
-    }, {
-      "type": "O",
-      "frame": 27,
-      "at": 2010
-    }, {
-      "type": "O",
-      "frame": 74,
-      "at": 2010
-    }, {
-      "type": "O",
-      "frame": 29,
-      "at": 2019
-    }, {
-      "type": "O",
-      "frame": 30,
-      "at": 2022
-    }, {
-      "type": "O",
-      "frame": 31,
-      "at": 2024
-    }, {
-      "type": "O",
-      "frame": 32,
-      "at": 2027
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 2028
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 2036
-    }, {
-      "type": "C",
-      "frame": 32,
-      "at": 2036
-    }, {
-      "type": "O",
-      "frame": 33,
-      "at": 2036
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 2037
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 2042
-    }, {
-      "type": "C",
-      "frame": 33,
-      "at": 2042
-    }, {
-      "type": "C",
-      "frame": 31,
-      "at": 2042
-    }, {
-      "type": "C",
-      "frame": 30,
-      "at": 2042
-    }, {
-      "type": "O",
-      "frame": 34,
-      "at": 2042
-    }, {
-      "type": "C",
-      "frame": 34,
-      "at": 2047
-    }, {
-      "type": "O",
-      "frame": 35,
-      "at": 2047
-    }, {
-      "type": "O",
-      "frame": 2,
-      "at": 2048
-    }, {
-      "type": "O",
-      "frame": 36,
-      "at": 2051
-    }, {
-      "type": "O",
-      "frame": 37,
-      "at": 2054
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 2055
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 2072
-    }, {
-      "type": "C",
-      "frame": 37,
-      "at": 2072
-    }, {
-      "type": "O",
-      "frame": 38,
-      "at": 2072
-    }, {
-      "type": "O",
-      "frame": 39,
-      "at": 2074
-    }, {
-      "type": "O",
-      "frame": 40,
-      "at": 2077
-    }, {
-      "type": "O",
-      "frame": 41,
-      "at": 2079
-    }, {
-      "type": "O",
-      "frame": 42,
-      "at": 2082
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 2083
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 2094
-    }, {
-      "type": "C",
-      "frame": 42,
-      "at": 2094
-    }, {
-      "type": "O",
-      "frame": 43,
-      "at": 2094
-    }, {
-      "type": "O",
-      "frame": 7,
-      "at": 2095
-    }, {
-      "type": "C",
-      "frame": 7,
-      "at": 2108
-    }, {
-      "type": "C",
-      "frame": 43,
-      "at": 2108
-    }, {
-      "type": "C",
-      "frame": 41,
-      "at": 2108
-    }, {
-      "type": "C",
-      "frame": 40,
-      "at": 2108
-    }, {
-      "type": "O",
-      "frame": 44,
-      "at": 2108
-    }, {
-      "type": "O",
-      "frame": 45,
-      "at": 2110
-    }, {
-      "type": "O",
-      "frame": 46,
-      "at": 2113
-    }, {
-      "type": "O",
-      "frame": 47,
-      "at": 2114
-    }, {
-      "type": "C",
-      "frame": 47,
-      "at": 2122
-    }, {
-      "type": "C",
-      "frame": 46,
-      "at": 2122
-    }, {
-      "type": "C",
-      "frame": 45,
-      "at": 2122
-    }, {
-      "type": "C",
-      "frame": 44,
-      "at": 2122
-    }, {
-      "type": "O",
-      "frame": 48,
-      "at": 2122
-    }, {
-      "type": "O",
-      "frame": 49,
-      "at": 2124
-    }, {
-      "type": "O",
-      "frame": 50,
-      "at": 2127
-    }, {
-      "type": "O",
-      "frame": 51,
-      "at": 2129
-    }, {
-      "type": "O",
-      "frame": 52,
-      "at": 2132
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 2133
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 2137
-    }, {
-      "type": "C",
-      "frame": 52,
-      "at": 2137
-    }, {
-      "type": "C",
-      "frame": 51,
-      "at": 2137
-    }, {
-      "type": "C",
-      "frame": 50,
-      "at": 2137
-    }, {
-      "type": "C",
-      "frame": 49,
-      "at": 2137
-    }, {
-      "type": "C",
-      "frame": 48,
-      "at": 2137
-    }, {
-      "type": "C",
-      "frame": 39,
-      "at": 2137
-    }, {
-      "type": "C",
-      "frame": 38,
-      "at": 2137
-    }, {
-      "type": "O",
-      "frame": 53,
-      "at": 2137
-    }, {
-      "type": "O",
-      "frame": 54,
-      "at": 2138
-    }, {
-      "type": "O",
-      "frame": 55,
-      "at": 2141
-    }, {
-      "type": "C",
-      "frame": 55,
-      "at": 2146
-    }, {
-      "type": "O",
-      "frame": 56,
-      "at": 2146
-    }, {
-      "type": "C",
-      "frame": 56,
-      "at": 2151
-    }, {
-      "type": "O",
-      "frame": 57,
-      "at": 2151
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 2152
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 2156
-    }, {
-      "type": "C",
-      "frame": 57,
-      "at": 2156
-    }, {
-      "type": "O",
-      "frame": 58,
-      "at": 2156
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 2157
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 2161
-    }, {
-      "type": "C",
-      "frame": 58,
-      "at": 2161
-    }, {
-      "type": "O",
-      "frame": 59,
-      "at": 2161
-    }, {
-      "type": "C",
-      "frame": 59,
-      "at": 2166
-    }, {
-      "type": "O",
-      "frame": 60,
-      "at": 2166
-    }, {
-      "type": "O",
-      "frame": 61,
-      "at": 2167
-    }, {
-      "type": "O",
-      "frame": 62,
-      "at": 2170
-    }, {
-      "type": "C",
-      "frame": 62,
-      "at": 2171
-    }, {
-      "type": "C",
-      "frame": 61,
-      "at": 2171
-    }, {
-      "type": "C",
-      "frame": 60,
-      "at": 2171
-    }, {
-      "type": "O",
-      "frame": 63,
-      "at": 2171
-    }, {
-      "type": "O",
-      "frame": 20,
-      "at": 2172
-    }, {
-      "type": "C",
-      "frame": 20,
-      "at": 2176
-    }, {
-      "type": "C",
-      "frame": 63,
-      "at": 2176
-    }, {
-      "type": "O",
-      "frame": 64,
-      "at": 2176
-    }, {
-      "type": "C",
-      "frame": 64,
-      "at": 2181
-    }, {
-      "type": "C",
-      "frame": 54,
-      "at": 2181
-    }, {
-      "type": "C",
-      "frame": 53,
-      "at": 2181
-    }, {
-      "type": "C",
-      "frame": 36,
-      "at": 2181
-    }, {
-      "type": "C",
-      "frame": 2,
-      "at": 2181
-    }, {
-      "type": "C",
-      "frame": 35,
-      "at": 2181
-    }, {
-      "type": "O",
-      "frame": 65,
-      "at": 2181
-    }, {
-      "type": "O",
-      "frame": 22,
-      "at": 2182
-    }, {
-      "type": "C",
-      "frame": 22,
-      "at": 2183
-    }, {
-      "type": "C",
-      "frame": 65,
-      "at": 2183
-    }, {
-      "type": "O",
-      "frame": 66,
-      "at": 2183
-    }, {
-      "type": "O",
-      "frame": 67,
-      "at": 2185
-    }, {
-      "type": "O",
-      "frame": 68,
-      "at": 2188
-    }, {
-      "type": "O",
-      "frame": 69,
-      "at": 2189
-    }, {
-      "type": "O",
-      "frame": 70,
-      "at": 2193
-    }, {
-      "type": "O",
-      "frame": 71,
-      "at": 2196
-    }, {
-      "type": "O",
-      "frame": 29,
-      "at": 2197
-    }, {
-      "type": "C",
-      "frame": 29,
-      "at": 2198
-    }, {
-      "type": "C",
-      "frame": 71,
-      "at": 2198
-    }, {
-      "type": "C",
-      "frame": 70,
-      "at": 2198
-    }, {
-      "type": "C",
-      "frame": 69,
-      "at": 2198
-    }, {
-      "type": "C",
-      "frame": 68,
-      "at": 2198
-    }, {
-      "type": "C",
-      "frame": 67,
-      "at": 2198
-    }, {
-      "type": "C",
-      "frame": 66,
-      "at": 2198
-    }, {
-      "type": "O",
-      "frame": 72,
-      "at": 2198
-    }, {
-      "type": "O",
-      "frame": 73,
-      "at": 2199
-    }, {
-      "type": "C",
-      "frame": 73,
-      "at": 2201
-    }, {
-      "type": "C",
-      "frame": 72,
-      "at": 2201
-    }, {
-      "type": "C",
-      "frame": 29,
-      "at": 2206
-    }, {
-      "type": "C",
-      "frame": 74,
-      "at": 2206
-    }, {
-      "type": "C",
-      "frame": 27,
-      "at": 2206
-    }, {
-      "type": "C",
-      "frame": 26,
-      "at": 2227
-    }]
-  }],
+  "profiles": [
+    {
+      "type": "evented",
+      "name": "fingerprint",
+      "unit": "bytes",
+      "startValue": 0,
+      "endValue": 754,
+      "events": [
+        {
+          "type": "O",
+          "frame": 0,
+          "at": 2
+        },
+        {
+          "type": "O",
+          "frame": 1,
+          "at": 92
+        },
+        {
+          "type": "O",
+          "frame": 2,
+          "at": 93
+        },
+        {
+          "type": "C",
+          "frame": 2,
+          "at": 94
+        },
+        {
+          "type": "C",
+          "frame": 1,
+          "at": 94
+        },
+        {
+          "type": "C",
+          "frame": 0,
+          "at": 94
+        },
+        {
+          "type": "O",
+          "frame": 3,
+          "at": 96
+        },
+        {
+          "type": "O",
+          "frame": 4,
+          "at": 192
+        },
+        {
+          "type": "O",
+          "frame": 5,
+          "at": 193
+        },
+        {
+          "type": "C",
+          "frame": 5,
+          "at": 271
+        },
+        {
+          "type": "C",
+          "frame": 4,
+          "at": 271
+        },
+        {
+          "type": "O",
+          "frame": 6,
+          "at": 271
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 272
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 320
+        },
+        {
+          "type": "C",
+          "frame": 6,
+          "at": 320
+        },
+        {
+          "type": "C",
+          "frame": 3,
+          "at": 320
+        },
+        {
+          "type": "O",
+          "frame": 8,
+          "at": 322
+        },
+        {
+          "type": "O",
+          "frame": 9,
+          "at": 410
+        },
+        {
+          "type": "O",
+          "frame": 5,
+          "at": 411
+        },
+        {
+          "type": "C",
+          "frame": 5,
+          "at": 563
+        },
+        {
+          "type": "C",
+          "frame": 9,
+          "at": 563
+        },
+        {
+          "type": "O",
+          "frame": 10,
+          "at": 563
+        },
+        {
+          "type": "O",
+          "frame": 11,
+          "at": 564
+        },
+        {
+          "type": "C",
+          "frame": 11,
+          "at": 581
+        },
+        {
+          "type": "C",
+          "frame": 10,
+          "at": 581
+        },
+        {
+          "type": "C",
+          "frame": 8,
+          "at": 581
+        },
+        {
+          "type": "O",
+          "frame": 8,
+          "at": 583
+        },
+        {
+          "type": "O",
+          "frame": 9,
+          "at": 586
+        },
+        {
+          "type": "O",
+          "frame": 5,
+          "at": 587
+        },
+        {
+          "type": "C",
+          "frame": 5,
+          "at": 736
+        },
+        {
+          "type": "C",
+          "frame": 9,
+          "at": 736
+        },
+        {
+          "type": "O",
+          "frame": 10,
+          "at": 736
+        },
+        {
+          "type": "O",
+          "frame": 11,
+          "at": 737
+        },
+        {
+          "type": "C",
+          "frame": 11,
+          "at": 754
+        },
+        {
+          "type": "C",
+          "frame": 10,
+          "at": 754
+        },
+        {
+          "type": "C",
+          "frame": 8,
+          "at": 754
+        }
+      ]
+    },
+    {
+      "type": "evented",
+      "name": "state",
+      "unit": "bytes",
+      "startValue": 0,
+      "endValue": 2227,
+      "events": [
+        {
+          "type": "O",
+          "frame": 12,
+          "at": 0
+        },
+        {
+          "type": "O",
+          "frame": 13,
+          "at": 6
+        },
+        {
+          "type": "C",
+          "frame": 13,
+          "at": 8
+        },
+        {
+          "type": "O",
+          "frame": 14,
+          "at": 8
+        },
+        {
+          "type": "O",
+          "frame": 15,
+          "at": 10
+        },
+        {
+          "type": "O",
+          "frame": 16,
+          "at": 59
+        },
+        {
+          "type": "C",
+          "frame": 16,
+          "at": 64
+        },
+        {
+          "type": "O",
+          "frame": 17,
+          "at": 64
+        },
+        {
+          "type": "C",
+          "frame": 17,
+          "at": 69
+        },
+        {
+          "type": "O",
+          "frame": 18,
+          "at": 69
+        },
+        {
+          "type": "C",
+          "frame": 18,
+          "at": 74
+        },
+        {
+          "type": "O",
+          "frame": 19,
+          "at": 74
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 75
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 79
+        },
+        {
+          "type": "C",
+          "frame": 19,
+          "at": 79
+        },
+        {
+          "type": "O",
+          "frame": 21,
+          "at": 79
+        },
+        {
+          "type": "O",
+          "frame": 22,
+          "at": 80
+        },
+        {
+          "type": "C",
+          "frame": 22,
+          "at": 81
+        },
+        {
+          "type": "C",
+          "frame": 21,
+          "at": 81
+        },
+        {
+          "type": "O",
+          "frame": 23,
+          "at": 81
+        },
+        {
+          "type": "O",
+          "frame": 22,
+          "at": 82
+        },
+        {
+          "type": "C",
+          "frame": 22,
+          "at": 83
+        },
+        {
+          "type": "C",
+          "frame": 23,
+          "at": 83
+        },
+        {
+          "type": "C",
+          "frame": 15,
+          "at": 83
+        },
+        {
+          "type": "C",
+          "frame": 14,
+          "at": 88
+        },
+        {
+          "type": "O",
+          "frame": 24,
+          "at": 88
+        },
+        {
+          "type": "C",
+          "frame": 24,
+          "at": 89
+        },
+        {
+          "type": "O",
+          "frame": 25,
+          "at": 89
+        },
+        {
+          "type": "C",
+          "frame": 25,
+          "at": 90
+        },
+        {
+          "type": "C",
+          "frame": 12,
+          "at": 95
+        },
+        {
+          "type": "O",
+          "frame": 26,
+          "at": 95
+        },
+        {
+          "type": "O",
+          "frame": 27,
+          "at": 669
+        },
+        {
+          "type": "O",
+          "frame": 28,
+          "at": 669
+        },
+        {
+          "type": "O",
+          "frame": 29,
+          "at": 703
+        },
+        {
+          "type": "O",
+          "frame": 30,
+          "at": 706
+        },
+        {
+          "type": "O",
+          "frame": 31,
+          "at": 708
+        },
+        {
+          "type": "O",
+          "frame": 32,
+          "at": 747
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 748
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 752
+        },
+        {
+          "type": "C",
+          "frame": 32,
+          "at": 752
+        },
+        {
+          "type": "O",
+          "frame": 33,
+          "at": 752
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 753
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 758
+        },
+        {
+          "type": "C",
+          "frame": 33,
+          "at": 758
+        },
+        {
+          "type": "C",
+          "frame": 31,
+          "at": 758
+        },
+        {
+          "type": "C",
+          "frame": 30,
+          "at": 758
+        },
+        {
+          "type": "O",
+          "frame": 34,
+          "at": 758
+        },
+        {
+          "type": "C",
+          "frame": 34,
+          "at": 763
+        },
+        {
+          "type": "O",
+          "frame": 35,
+          "at": 763
+        },
+        {
+          "type": "O",
+          "frame": 2,
+          "at": 764
+        },
+        {
+          "type": "O",
+          "frame": 36,
+          "at": 767
+        },
+        {
+          "type": "O",
+          "frame": 37,
+          "at": 826
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 827
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 844
+        },
+        {
+          "type": "C",
+          "frame": 37,
+          "at": 844
+        },
+        {
+          "type": "O",
+          "frame": 38,
+          "at": 844
+        },
+        {
+          "type": "O",
+          "frame": 39,
+          "at": 846
+        },
+        {
+          "type": "O",
+          "frame": 40,
+          "at": 938
+        },
+        {
+          "type": "O",
+          "frame": 41,
+          "at": 940
+        },
+        {
+          "type": "O",
+          "frame": 42,
+          "at": 979
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 980
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 991
+        },
+        {
+          "type": "C",
+          "frame": 42,
+          "at": 991
+        },
+        {
+          "type": "O",
+          "frame": 43,
+          "at": 991
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 992
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 1005
+        },
+        {
+          "type": "C",
+          "frame": 43,
+          "at": 1005
+        },
+        {
+          "type": "C",
+          "frame": 41,
+          "at": 1005
+        },
+        {
+          "type": "C",
+          "frame": 40,
+          "at": 1005
+        },
+        {
+          "type": "O",
+          "frame": 44,
+          "at": 1005
+        },
+        {
+          "type": "O",
+          "frame": 45,
+          "at": 1007
+        },
+        {
+          "type": "O",
+          "frame": 46,
+          "at": 1067
+        },
+        {
+          "type": "O",
+          "frame": 47,
+          "at": 1068
+        },
+        {
+          "type": "C",
+          "frame": 47,
+          "at": 1076
+        },
+        {
+          "type": "C",
+          "frame": 46,
+          "at": 1076
+        },
+        {
+          "type": "C",
+          "frame": 45,
+          "at": 1076
+        },
+        {
+          "type": "C",
+          "frame": 44,
+          "at": 1076
+        },
+        {
+          "type": "O",
+          "frame": 48,
+          "at": 1076
+        },
+        {
+          "type": "O",
+          "frame": 49,
+          "at": 1078
+        },
+        {
+          "type": "O",
+          "frame": 50,
+          "at": 1151
+        },
+        {
+          "type": "O",
+          "frame": 51,
+          "at": 1153
+        },
+        {
+          "type": "O",
+          "frame": 52,
+          "at": 1179
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 1180
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 1184
+        },
+        {
+          "type": "C",
+          "frame": 52,
+          "at": 1184
+        },
+        {
+          "type": "C",
+          "frame": 51,
+          "at": 1184
+        },
+        {
+          "type": "C",
+          "frame": 50,
+          "at": 1184
+        },
+        {
+          "type": "C",
+          "frame": 49,
+          "at": 1184
+        },
+        {
+          "type": "C",
+          "frame": 48,
+          "at": 1184
+        },
+        {
+          "type": "C",
+          "frame": 39,
+          "at": 1184
+        },
+        {
+          "type": "C",
+          "frame": 38,
+          "at": 1184
+        },
+        {
+          "type": "O",
+          "frame": 53,
+          "at": 1184
+        },
+        {
+          "type": "O",
+          "frame": 54,
+          "at": 1185
+        },
+        {
+          "type": "O",
+          "frame": 55,
+          "at": 1771
+        },
+        {
+          "type": "C",
+          "frame": 55,
+          "at": 1776
+        },
+        {
+          "type": "O",
+          "frame": 56,
+          "at": 1776
+        },
+        {
+          "type": "C",
+          "frame": 56,
+          "at": 1781
+        },
+        {
+          "type": "O",
+          "frame": 57,
+          "at": 1781
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 1782
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 1786
+        },
+        {
+          "type": "C",
+          "frame": 57,
+          "at": 1786
+        },
+        {
+          "type": "O",
+          "frame": 58,
+          "at": 1786
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 1787
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 1791
+        },
+        {
+          "type": "C",
+          "frame": 58,
+          "at": 1791
+        },
+        {
+          "type": "O",
+          "frame": 59,
+          "at": 1791
+        },
+        {
+          "type": "C",
+          "frame": 59,
+          "at": 1796
+        },
+        {
+          "type": "O",
+          "frame": 60,
+          "at": 1796
+        },
+        {
+          "type": "O",
+          "frame": 61,
+          "at": 1797
+        },
+        {
+          "type": "O",
+          "frame": 62,
+          "at": 1817
+        },
+        {
+          "type": "C",
+          "frame": 62,
+          "at": 1836
+        },
+        {
+          "type": "C",
+          "frame": 61,
+          "at": 1836
+        },
+        {
+          "type": "C",
+          "frame": 60,
+          "at": 1836
+        },
+        {
+          "type": "O",
+          "frame": 63,
+          "at": 1836
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 1837
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 1841
+        },
+        {
+          "type": "C",
+          "frame": 63,
+          "at": 1841
+        },
+        {
+          "type": "O",
+          "frame": 64,
+          "at": 1841
+        },
+        {
+          "type": "C",
+          "frame": 64,
+          "at": 1846
+        },
+        {
+          "type": "C",
+          "frame": 54,
+          "at": 1846
+        },
+        {
+          "type": "C",
+          "frame": 53,
+          "at": 1846
+        },
+        {
+          "type": "C",
+          "frame": 36,
+          "at": 1846
+        },
+        {
+          "type": "C",
+          "frame": 2,
+          "at": 1846
+        },
+        {
+          "type": "C",
+          "frame": 35,
+          "at": 1846
+        },
+        {
+          "type": "O",
+          "frame": 65,
+          "at": 1846
+        },
+        {
+          "type": "O",
+          "frame": 22,
+          "at": 1847
+        },
+        {
+          "type": "C",
+          "frame": 22,
+          "at": 1848
+        },
+        {
+          "type": "C",
+          "frame": 65,
+          "at": 1848
+        },
+        {
+          "type": "O",
+          "frame": 66,
+          "at": 1848
+        },
+        {
+          "type": "O",
+          "frame": 67,
+          "at": 1850
+        },
+        {
+          "type": "O",
+          "frame": 68,
+          "at": 1883
+        },
+        {
+          "type": "O",
+          "frame": 69,
+          "at": 1884
+        },
+        {
+          "type": "O",
+          "frame": 70,
+          "at": 1915
+        },
+        {
+          "type": "O",
+          "frame": 71,
+          "at": 1958
+        },
+        {
+          "type": "O",
+          "frame": 29,
+          "at": 1959
+        },
+        {
+          "type": "C",
+          "frame": 29,
+          "at": 1960
+        },
+        {
+          "type": "C",
+          "frame": 71,
+          "at": 1960
+        },
+        {
+          "type": "C",
+          "frame": 70,
+          "at": 1960
+        },
+        {
+          "type": "C",
+          "frame": 69,
+          "at": 1960
+        },
+        {
+          "type": "C",
+          "frame": 68,
+          "at": 1960
+        },
+        {
+          "type": "C",
+          "frame": 67,
+          "at": 1960
+        },
+        {
+          "type": "C",
+          "frame": 66,
+          "at": 1960
+        },
+        {
+          "type": "O",
+          "frame": 72,
+          "at": 1960
+        },
+        {
+          "type": "O",
+          "frame": 73,
+          "at": 1961
+        },
+        {
+          "type": "C",
+          "frame": 73,
+          "at": 1983
+        },
+        {
+          "type": "C",
+          "frame": 72,
+          "at": 1983
+        },
+        {
+          "type": "C",
+          "frame": 29,
+          "at": 1988
+        },
+        {
+          "type": "C",
+          "frame": 28,
+          "at": 1988
+        },
+        {
+          "type": "C",
+          "frame": 27,
+          "at": 1988
+        },
+        {
+          "type": "O",
+          "frame": 27,
+          "at": 2010
+        },
+        {
+          "type": "O",
+          "frame": 74,
+          "at": 2010
+        },
+        {
+          "type": "O",
+          "frame": 29,
+          "at": 2019
+        },
+        {
+          "type": "O",
+          "frame": 30,
+          "at": 2022
+        },
+        {
+          "type": "O",
+          "frame": 31,
+          "at": 2024
+        },
+        {
+          "type": "O",
+          "frame": 32,
+          "at": 2027
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 2028
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 2036
+        },
+        {
+          "type": "C",
+          "frame": 32,
+          "at": 2036
+        },
+        {
+          "type": "O",
+          "frame": 33,
+          "at": 2036
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 2037
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 2042
+        },
+        {
+          "type": "C",
+          "frame": 33,
+          "at": 2042
+        },
+        {
+          "type": "C",
+          "frame": 31,
+          "at": 2042
+        },
+        {
+          "type": "C",
+          "frame": 30,
+          "at": 2042
+        },
+        {
+          "type": "O",
+          "frame": 34,
+          "at": 2042
+        },
+        {
+          "type": "C",
+          "frame": 34,
+          "at": 2047
+        },
+        {
+          "type": "O",
+          "frame": 35,
+          "at": 2047
+        },
+        {
+          "type": "O",
+          "frame": 2,
+          "at": 2048
+        },
+        {
+          "type": "O",
+          "frame": 36,
+          "at": 2051
+        },
+        {
+          "type": "O",
+          "frame": 37,
+          "at": 2054
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 2055
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 2072
+        },
+        {
+          "type": "C",
+          "frame": 37,
+          "at": 2072
+        },
+        {
+          "type": "O",
+          "frame": 38,
+          "at": 2072
+        },
+        {
+          "type": "O",
+          "frame": 39,
+          "at": 2074
+        },
+        {
+          "type": "O",
+          "frame": 40,
+          "at": 2077
+        },
+        {
+          "type": "O",
+          "frame": 41,
+          "at": 2079
+        },
+        {
+          "type": "O",
+          "frame": 42,
+          "at": 2082
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 2083
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 2094
+        },
+        {
+          "type": "C",
+          "frame": 42,
+          "at": 2094
+        },
+        {
+          "type": "O",
+          "frame": 43,
+          "at": 2094
+        },
+        {
+          "type": "O",
+          "frame": 7,
+          "at": 2095
+        },
+        {
+          "type": "C",
+          "frame": 7,
+          "at": 2108
+        },
+        {
+          "type": "C",
+          "frame": 43,
+          "at": 2108
+        },
+        {
+          "type": "C",
+          "frame": 41,
+          "at": 2108
+        },
+        {
+          "type": "C",
+          "frame": 40,
+          "at": 2108
+        },
+        {
+          "type": "O",
+          "frame": 44,
+          "at": 2108
+        },
+        {
+          "type": "O",
+          "frame": 45,
+          "at": 2110
+        },
+        {
+          "type": "O",
+          "frame": 46,
+          "at": 2113
+        },
+        {
+          "type": "O",
+          "frame": 47,
+          "at": 2114
+        },
+        {
+          "type": "C",
+          "frame": 47,
+          "at": 2122
+        },
+        {
+          "type": "C",
+          "frame": 46,
+          "at": 2122
+        },
+        {
+          "type": "C",
+          "frame": 45,
+          "at": 2122
+        },
+        {
+          "type": "C",
+          "frame": 44,
+          "at": 2122
+        },
+        {
+          "type": "O",
+          "frame": 48,
+          "at": 2122
+        },
+        {
+          "type": "O",
+          "frame": 49,
+          "at": 2124
+        },
+        {
+          "type": "O",
+          "frame": 50,
+          "at": 2127
+        },
+        {
+          "type": "O",
+          "frame": 51,
+          "at": 2129
+        },
+        {
+          "type": "O",
+          "frame": 52,
+          "at": 2132
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 2133
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 2137
+        },
+        {
+          "type": "C",
+          "frame": 52,
+          "at": 2137
+        },
+        {
+          "type": "C",
+          "frame": 51,
+          "at": 2137
+        },
+        {
+          "type": "C",
+          "frame": 50,
+          "at": 2137
+        },
+        {
+          "type": "C",
+          "frame": 49,
+          "at": 2137
+        },
+        {
+          "type": "C",
+          "frame": 48,
+          "at": 2137
+        },
+        {
+          "type": "C",
+          "frame": 39,
+          "at": 2137
+        },
+        {
+          "type": "C",
+          "frame": 38,
+          "at": 2137
+        },
+        {
+          "type": "O",
+          "frame": 53,
+          "at": 2137
+        },
+        {
+          "type": "O",
+          "frame": 54,
+          "at": 2138
+        },
+        {
+          "type": "O",
+          "frame": 55,
+          "at": 2141
+        },
+        {
+          "type": "C",
+          "frame": 55,
+          "at": 2146
+        },
+        {
+          "type": "O",
+          "frame": 56,
+          "at": 2146
+        },
+        {
+          "type": "C",
+          "frame": 56,
+          "at": 2151
+        },
+        {
+          "type": "O",
+          "frame": 57,
+          "at": 2151
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 2152
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 2156
+        },
+        {
+          "type": "C",
+          "frame": 57,
+          "at": 2156
+        },
+        {
+          "type": "O",
+          "frame": 58,
+          "at": 2156
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 2157
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 2161
+        },
+        {
+          "type": "C",
+          "frame": 58,
+          "at": 2161
+        },
+        {
+          "type": "O",
+          "frame": 59,
+          "at": 2161
+        },
+        {
+          "type": "C",
+          "frame": 59,
+          "at": 2166
+        },
+        {
+          "type": "O",
+          "frame": 60,
+          "at": 2166
+        },
+        {
+          "type": "O",
+          "frame": 61,
+          "at": 2167
+        },
+        {
+          "type": "O",
+          "frame": 62,
+          "at": 2170
+        },
+        {
+          "type": "C",
+          "frame": 62,
+          "at": 2171
+        },
+        {
+          "type": "C",
+          "frame": 61,
+          "at": 2171
+        },
+        {
+          "type": "C",
+          "frame": 60,
+          "at": 2171
+        },
+        {
+          "type": "O",
+          "frame": 63,
+          "at": 2171
+        },
+        {
+          "type": "O",
+          "frame": 20,
+          "at": 2172
+        },
+        {
+          "type": "C",
+          "frame": 20,
+          "at": 2176
+        },
+        {
+          "type": "C",
+          "frame": 63,
+          "at": 2176
+        },
+        {
+          "type": "O",
+          "frame": 64,
+          "at": 2176
+        },
+        {
+          "type": "C",
+          "frame": 64,
+          "at": 2181
+        },
+        {
+          "type": "C",
+          "frame": 54,
+          "at": 2181
+        },
+        {
+          "type": "C",
+          "frame": 53,
+          "at": 2181
+        },
+        {
+          "type": "C",
+          "frame": 36,
+          "at": 2181
+        },
+        {
+          "type": "C",
+          "frame": 2,
+          "at": 2181
+        },
+        {
+          "type": "C",
+          "frame": 35,
+          "at": 2181
+        },
+        {
+          "type": "O",
+          "frame": 65,
+          "at": 2181
+        },
+        {
+          "type": "O",
+          "frame": 22,
+          "at": 2182
+        },
+        {
+          "type": "C",
+          "frame": 22,
+          "at": 2183
+        },
+        {
+          "type": "C",
+          "frame": 65,
+          "at": 2183
+        },
+        {
+          "type": "O",
+          "frame": 66,
+          "at": 2183
+        },
+        {
+          "type": "O",
+          "frame": 67,
+          "at": 2185
+        },
+        {
+          "type": "O",
+          "frame": 68,
+          "at": 2188
+        },
+        {
+          "type": "O",
+          "frame": 69,
+          "at": 2189
+        },
+        {
+          "type": "O",
+          "frame": 70,
+          "at": 2193
+        },
+        {
+          "type": "O",
+          "frame": 71,
+          "at": 2196
+        },
+        {
+          "type": "O",
+          "frame": 29,
+          "at": 2197
+        },
+        {
+          "type": "C",
+          "frame": 29,
+          "at": 2198
+        },
+        {
+          "type": "C",
+          "frame": 71,
+          "at": 2198
+        },
+        {
+          "type": "C",
+          "frame": 70,
+          "at": 2198
+        },
+        {
+          "type": "C",
+          "frame": 69,
+          "at": 2198
+        },
+        {
+          "type": "C",
+          "frame": 68,
+          "at": 2198
+        },
+        {
+          "type": "C",
+          "frame": 67,
+          "at": 2198
+        },
+        {
+          "type": "C",
+          "frame": 66,
+          "at": 2198
+        },
+        {
+          "type": "O",
+          "frame": 72,
+          "at": 2198
+        },
+        {
+          "type": "O",
+          "frame": 73,
+          "at": 2199
+        },
+        {
+          "type": "C",
+          "frame": 73,
+          "at": 2201
+        },
+        {
+          "type": "C",
+          "frame": 72,
+          "at": 2201
+        },
+        {
+          "type": "C",
+          "frame": 29,
+          "at": 2206
+        },
+        {
+          "type": "C",
+          "frame": 74,
+          "at": 2206
+        },
+        {
+          "type": "C",
+          "frame": 27,
+          "at": 2206
+        },
+        {
+          "type": "C",
+          "frame": 26,
+          "at": 2227
+        }
+      ]
+    }
+  ],
   "name": "Gradle Configuration Cache Space Usage"
 }


### PR DESCRIPTION
More specifically, an H2 database is now used for the aggregation events.

Processing is now parallelized among 3 coroutines:
- the parser: scans the Gradle debug log for matching events
- the aggregator: aggregates the events into profiles
- the writer: outputs the final json for the aggregates