### PR TITLE
Allow frame filter to be specified via GCC2SS_INCLUDE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,31 @@ Produce a speedscope document from a Gradle debug log file:
 Produce a speedscope document from a Gradle build:
 
     $ ./gradlew assemble --configuration-cache -d | gcc2ss -- >> speedscope.json
+
+### Dealing with information overload
+
+Some larger builds might generate too much information. This can be more than
+what speedscope can currently handle.
+
+You might also want to focus the space usage report on a subset of objects for
+quicker iterations.
+
+For those scenarios, `gcc2ss` allows the space usage events to be filtered via a
+regular expression provided in the `GCC2SS_INCLUDE` environment variable.
+
+Only objects whose name match the provided pattern fully will be included in the
+final document. The term `object` is being used loosely to mean any named
+delimited piece of information (i.e. `frame`) stored to the cache, for example:
+* Gradle task instance frames are named with the task absolute path
+* Java type frames are named with the full class name of the stored object
+* Java type field frames are named `${qualifiedClassName}.${fieldName}`
+
+For a comprehensive and up-to-date list of possible `frame` names, check the
+call hierarchy of
+[`withDebugFrame`](https://github.com/gradle/gradle/blob/5b5514c90d99f506f77d0b789b5d38dcf4bafd57/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Logging.kt#L128)
+in the Gradle codebase.
+
+For instance, to quickly gain an understanding of which tasks are occupying more
+space (task names always start with `:`), the following command line would work:
+
+    $ GCC2SS_INCLUDE=":.+" gcc2ss ~/my/debug.log >> tasks.json

--- a/src/main/kotlin/gcc2speedscope/App.kt
+++ b/src/main/kotlin/gcc2speedscope/App.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.Reader
 import java.io.Writer
+import java.lang.System.getenv
 import java.nio.file.Files
 import java.nio.file.Files.newBufferedReader
 import java.nio.file.Paths
@@ -32,8 +33,9 @@ fun main(args: Array<String>) {
         writeSpeedscopeDocumentTo(
             writer,
             debugLogReader,
-            prettyPrint = System.getenv("GCC2SS_PRETTY_PRINT") !== null,
-            databaseFile = System.getenv("GCC2SS_DATABASE") ?: createTempDatabaseFile()
+            prettyPrint = getenv("GCC2SS_PRETTY_PRINT") !== null,
+            databaseFile = getenv("GCC2SS_DATABASE")
+                ?: createTempDatabaseFile()
         )
     }
 }
@@ -51,11 +53,11 @@ fun writeSpeedscopeDocumentTo(
     databaseFile: String
 ): Unit = runBlocking {
 
-    val channelCapacity = System.getenv("GCC2SS_CHANNEL_CAPACITY")?.toInt()
+    val channelCapacity = getenv("GCC2SS_CHANNEL_CAPACITY")?.toInt()
         ?: 1024
 
     val parsedEventFilter: ParsedEvent.() -> Boolean =
-        System.getenv("GCC2SS_INCLUDE")
+        getenv("GCC2SS_INCLUDE")
             ?.let(Pattern::compile)
             ?.let { pattern -> { pattern.matcher(frame).matches() } }
             ?: { true }

--- a/src/main/kotlin/gcc2speedscope/App.kt
+++ b/src/main/kotlin/gcc2speedscope/App.kt
@@ -1,5 +1,6 @@
 package gcc2speedscope
 
+import com.google.gson.JsonObject
 import com.google.gson.JsonParseException
 import com.google.gson.JsonParser
 import com.google.gson.stream.JsonWriter
@@ -231,22 +232,32 @@ fun configurationCacheEventsFromDebugLogLines(lines: Sequence<String>) = sequenc
         if (matcher.matches()) {
             val jsonEvent = matcher.group(1)
             try {
-                val jsonObject = JsonParser.parseString(jsonEvent).asJsonObject
-                yield(jsonObject.run {
-                    ParsedEvent(
-                        sequenceNumber = get("sn")!!.asLong,
-                        profile = get("profile")!!.asString,
-                        type = get("type")!!.asString,
-                        frame = get("frame")!!.asString,
-                        at = get("at")!!.asLong
-                    )
-                })
+                val parsedEvent = JsonParser
+                    .parseString(jsonEvent)
+                    .asJsonObject.run {
+                        ParsedEvent(
+                            sequenceNumber = getLong("sn"),
+                            profile = getString("profile"),
+                            type = getString("type"),
+                            frame = getString("frame"),
+                            at = getLong("at")
+                        )
+                    }
+                yield(parsedEvent)
             } catch (e: JsonParseException) {
                 throw IllegalArgumentException("line ${index + 1}: failed to parse $jsonEvent", e)
             }
         }
     }
 }
+
+
+private
+fun JsonObject.getString(memberName: String): String = get(memberName)!!.asString
+
+
+private
+fun JsonObject.getLong(memberName: String) = get(memberName)!!.asLong
 
 
 private


### PR DESCRIPTION
For example, to more quickly get an overview of which tasks are using more space, the following command line would work:

    GCC2SS_INCLUDE=":.+" gcc2ss debug.log >> tasks.json